### PR TITLE
fix(interceptor): fix rpc exception message in http to grpc interceptor

### DIFF
--- a/lib/interceptors/grpc-to-http.interceptor.ts
+++ b/lib/interceptors/grpc-to-http.interceptor.ts
@@ -29,33 +29,17 @@ export class GrpcToHttpInterceptor implements NestInterceptor {
         )
           return throwError(() => err);
 
-        const statusCode =
-          HTTP_CODE_FROM_GRPC[err.code] || HttpStatus.INTERNAL_SERVER_ERROR;
-
-        let exception: { exceptionName: any; error: any; type?: string };
-        try {
-          exception = JSON.parse(err.details) as {
-            error: string | object;
-            type: string;
-            exceptionName: string;
-          };
-        } catch (parseError) {
-          return throwError(
-            () =>
-              new HttpException(
-                {
-                  message: err.details,
-                  statusCode,
-                  error: HttpStatus[statusCode],
-                },
-                statusCode,
-                { cause: err },
-              ),
-          );
-        }
+        const exception = JSON.parse(err.details) as {
+          error: string | object;
+          type: string;
+          exceptionName: string;
+        };
 
         if (exception.exceptionName !== RpcException.name)
           return throwError(() => err);
+
+        const statusCode =
+          HTTP_CODE_FROM_GRPC[err.code] || HttpStatus.INTERNAL_SERVER_ERROR;
 
         return throwError(
           () =>

--- a/lib/interceptors/http-to-grpc.interceptor.ts
+++ b/lib/interceptors/http-to-grpc.interceptor.ts
@@ -40,7 +40,12 @@ export class HttpToGrpcInterceptor implements NestInterceptor {
         return throwError(
           () =>
             new RpcException({
-              message: exception.message,
+              message: JSON.stringify({
+                error: exception.message,
+                type:
+                  typeof exception.message === "string" ? "string" : "object",
+                exceptionName: RpcException.name,
+              }),
               code: statusCode,
             }),
         );


### PR DESCRIPTION
Handles all sorts of http exceptions from rpc client. No need to use extra try catch for parse error in grpc to http interceptor.

Refs: #13